### PR TITLE
Avoid putting a padding to the headers for which sorting is disabled 

### DIFF
--- a/css/dataTables.bootstrap4.css
+++ b/css/dataTables.bootstrap4.css
@@ -158,7 +158,7 @@ div.dataTables_scrollFoot > .dataTables_scrollFootInner > table {
     text-align: center;
   }
 }
-table.dataTable.table-sm > thead > tr > th {
+table.dataTable.table-sm > thead > tr > th :not(.sorting_disabled){
   padding-right: 20px;
 }
 table.dataTable.table-sm .sorting:before,


### PR DESCRIPTION
I don't know if there are more to this or if it would break some other rules but as of my testing it should be fine to remove this rule for headers that have no sorting applied to them. 

This is the case already for "normal sized" tables as the padding-right rule is only applied if there is a sorting class to the element. But it has been forgotten for the table-sm variant. So there are two options that I can see.
1. Specify this rule does not apply if there is a sorting_disabled class
2. Do the same as what was done for the normal sized table in the following commit: 4e611f31ff84deae5ae4666c7ba60ad8cb1012c3